### PR TITLE
expose useful infomations

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1,5 +1,6 @@
 import {
   ActionSequence,
+  BrowserCapability,
   Cookie,
   LocatorStrategy,
   Timeouts,
@@ -16,10 +17,12 @@ import { DELETE, GET, POST } from './rest';
 export class Session {
   private readonly host: string;
   private readonly sessionId: string;
+  public readonly capabilities: BrowserCapability;
 
-  constructor(host: string, sessionId: string) {
+  constructor(host: string, sessionId: string, capabilities: BrowserCapability) {
     this.host = host;
     this.sessionId = sessionId;
+    this.capabilities = capabilities;
   }
 
   /****************************************************************************************************************

--- a/src/core/WebdriverError.ts
+++ b/src/core/WebdriverError.ts
@@ -1,0 +1,5 @@
+export class WebdriverError extends Error {
+  constructor(public error = '', message = '') {
+    super(message);
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,4 +5,5 @@ export * from './ElementRect';
 export * from './LocatorStrategy';
 export * from './Status';
 export * from './Timeout';
+export * from './WebdriverError';
 export * from './WindowRect';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Headers } from 'request';
-import { Capabilities, Status } from './core';
+import { BrowserCapability, Capabilities, Status } from './core';
 import { GET, POST } from './rest';
 import { Session } from './Session';
 
@@ -69,8 +69,9 @@ export async function newSession(options: {
   headers?: Headers;
 }): Promise<Session> {
   const { url, capabilities, desiredCapabilities, headers } = options;
-  const { sessionId } = await POST<{
+  const { sessionId, capabilities: capabilitiesResponse } = await POST<{
     sessionId: string;
+    capabilities: BrowserCapability;
   }>(
     `${url}/session`,
     {
@@ -80,7 +81,7 @@ export async function newSession(options: {
     headers
   );
 
-  return new Session(url, sessionId);
+  return new Session(url, sessionId, capabilitiesResponse);
 }
 /**
  * To be able to verify if the WebDriver server is ready for new session creation sometimes it can be useful to query it's status.

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,5 +1,6 @@
 import request, { Headers } from 'request';
 import util from 'util';
+import { WebdriverError } from './core';
 import { log } from './logger';
 
 interface ErrorValue {
@@ -68,7 +69,7 @@ async function sendRequest<T>(
   if (isError(value)) {
     const { error, message } = value;
 
-    throw new Error(message || error);
+    throw new WebdriverError(error, message);
   }
 
   return value;

--- a/test-env/index.ts
+++ b/test-env/index.ts
@@ -207,7 +207,7 @@ const webDriverHost = process.env.BROWSERSTACK
   ? WebDriverHost.BrowserStack
   : WebDriverHost.Localhost;
 const testEnv: TestEnvironment = {
-  session: new Session('default', 'default'),
+  session: new Session('default', 'default', {}),
   headless: !!process.env.HEADLESS,
   setInitialWindowRectangle(rect: WindowRect) {
     initialWindowRect = rect;


### PR DESCRIPTION
Hi,

I'm doing some webdriver testing which client UI is in a browser, your package just match my requirement and it work fine.

However, when I try to access some response data form server, I found that some of them are discarded in the package.
So, here is some modify to expose the `error` type in error message and the accurate `capabilities` that what environment browser is using.

Btw, not sure it's my problem, the lint in pre-commit work strange, it trying to add brackets and commas in some place I'm not modify, so I disable it in my commit, just let you known that.